### PR TITLE
fix(router): replace dioxus_router with dioxus::router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "dioxus-hooks",
  "dioxus-html",
  "dioxus-logger",
+ "dioxus-router",
  "dioxus-signals",
  "dioxus-stores",
  "dioxus-web",
@@ -523,7 +524,6 @@ name = "dioxus-bulma"
 version = "0.7.2"
 dependencies = [
  "dioxus",
- "dioxus-router",
  "manganis",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,10 @@ keywords = ["dioxus", "bulma", "components", "ui", "web"]
 categories = ["gui", "web-programming"]
 
 [dependencies]
-dioxus = "0.7"
-dioxus-router = { version = "0.7", optional = true }
+dioxus = { version = "0.7" }
 
 [dev-dependencies]
 dioxus = { version = "0.7", features = ["web"] }
-dioxus-router = "0.7"
 manganis = "0.7"
 
 [[example]]
@@ -27,7 +25,7 @@ required-features = ["web"]
 [features]
 default = []
 web = ["dioxus/web"]
-router = ["dioxus-router"]
+router = ["dioxus/router"]
 
 [profile]
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,6 @@ Use components with dioxus-router for client-side navigation:
 
 ```rust
 use dioxus::prelude::*;
-use dioxus_router::prelude::*;
 use dioxus_bulma::*;
 
 #[derive(Clone, Routable, Debug, PartialEq)]

--- a/src/components/breadcrumb.rs
+++ b/src/components/breadcrumb.rs
@@ -1,9 +1,6 @@
-use dioxus::prelude::*;
 use crate::theme::BulmaSize;
 use crate::utils::build_class;
-
-#[cfg(feature = "router")]
-use dioxus_router::prelude::*;
+use dioxus::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BreadcrumbSeparator {

--- a/src/components/button.rs
+++ b/src/components/button.rs
@@ -1,9 +1,6 @@
-use dioxus::prelude::*;
 use crate::theme::{BulmaColor, BulmaSize};
 use crate::utils::build_class;
-
-#[cfg(feature = "router")]
-use dioxus_router::prelude::*;
+use dioxus::prelude::*;
 
 #[derive(Props, Clone, PartialEq)]
 pub struct ButtonProps {

--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -1,8 +1,5 @@
-use dioxus::prelude::*;
 use crate::utils::build_class;
-
-#[cfg(feature = "router")]
-use dioxus_router::prelude::*;
+use dioxus::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum DropdownTrigger {

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -1,8 +1,5 @@
-use dioxus::prelude::*;
 use crate::utils::build_class;
-
-#[cfg(feature = "router")]
-use dioxus_router::prelude::*;
+use dioxus::prelude::*;
 
 #[derive(Props, Clone, PartialEq)]
 pub struct MenuProps {

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -1,9 +1,6 @@
-use dioxus::prelude::*;
 use crate::theme::BulmaSize;
 use crate::utils::build_class;
-
-#[cfg(feature = "router")]
-use dioxus_router::prelude::*;
+use dioxus::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PaginationAlignment {

--- a/src/components/panel.rs
+++ b/src/components/panel.rs
@@ -1,9 +1,6 @@
-use dioxus::prelude::*;
 use crate::theme::BulmaColor;
 use crate::utils::build_class;
-
-#[cfg(feature = "router")]
-use dioxus_router::prelude::*;
+use dioxus::prelude::*;
 
 #[derive(Props, Clone, PartialEq)]
 pub struct PanelProps {

--- a/src/components/tabs.rs
+++ b/src/components/tabs.rs
@@ -1,9 +1,6 @@
-use dioxus::prelude::*;
 use crate::theme::BulmaSize;
 use crate::utils::build_class;
-
-#[cfg(feature = "router")]
-use dioxus_router::prelude::*;
+use dioxus::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TabsStyle {


### PR DESCRIPTION
Module dioxus_router::prelude got removed in 0.7.2 - so cargo build fails with `router` feature enabled.

But it's present in `dioxus` crate gated by `router` feature.

So it seems better to not depend on dioxus-router at all, and just depend on dioxus with router feature enabled.